### PR TITLE
Swapping alpha, beta. Plus some flake8 compliance

### DIFF
--- a/dist_q_learning/main.py
+++ b/dist_q_learning/main.py
@@ -24,6 +24,7 @@ if __name__ == "__main__":
         print("Reward, done:", rew, done)
     assert rew == -0.
 
-    a = FinitePessimisticAgent(env.num_actions, env.num_states, env, prudent_mentor, 1, 0.99)
+    a = FinitePessimisticAgent(
+        env.num_actions, env.num_states, env, prudent_mentor, 1, 0.99)
     
-    a.learn(5,render=False)
+    a.learn(5, render=False)

--- a/dist_q_learning/test_estimators.py
+++ b/dist_q_learning/test_estimators.py
@@ -1,8 +1,9 @@
+import numpy as np
 from unittest import TestCase
 
-from estimators import ImmediateRewardEstimator, plot_beta, QEstimator, MentorQEstimator
+from estimators import (
+    ImmediateRewardEstimator, plot_beta, QEstimator, MentorQEstimator)
 
-import numpy as np
 
 class TestImmediateRewardEstimator(TestCase):
 
@@ -51,10 +52,8 @@ class TestImmediateRewardEstimator(TestCase):
 
 class TestQEstimator(TestCase):
 
-
     def initialise_IREs(self):
         IREs=[]
-
         for i in range(2):
             IREs.append(ImmediateRewardEstimator(i))
             IREs[i].state_dict = {0: [0., 0.8, 1.], 1: [0., 1., 0.3]}
@@ -62,19 +61,20 @@ class TestQEstimator(TestCase):
         return IREs
 
     def test_estimate(self):
-        IREs =  self.initialise_IREs()
+        IREs = self.initialise_IREs()
         Q = QEstimator(0.5, IREs, 0.99, 4, 2)
-        Q.estimate(0,1)
+        Q.estimate(0, 1)
         print('hi')
 
     def test_update(self):
         IREs =  self.initialise_IREs()
 
         Q = QEstimator(0.5, IREs, 0.99, 4, 2, lr=10)
-        assert np.all(Q.Q_table==0.5)
+        assert np.all(Q.Q_table == 0.5)
         print(Q.Q_table)
-        Q.update([(0,1,0.9,2), (1,0,0.9,3)])
-        # assert Q.Q_table[0,1] == Q.quantile + Q.lr * (self.IREs[1].estimate(0)*(1 - Q.gamma) + Q.gamma * 0.5 - Q.quantile)
+        Q.update([(0, 1, 0.9, 2), (1, 0, 0.9, 3)])
+        # assert Q.Q_table[0,1] == Q.quantile + Q.lr *
+        # (self.IREs[1].estimate(0)*(1 - Q.gamma) + Q.gamma * 0.5 - Q.quantile)
         print(Q.Q_table)
 
 
@@ -87,9 +87,7 @@ class TestMentorQEstimator(TestCase):
 
     def test_update(self):
         MQ = MentorQEstimator(4, 2, 0.99)
-        assert np.all(MQ.Q_list==1)
+        assert np.all(MQ.Q_list == 1)
         print(MQ.Q_list)
-        MQ.update([(0,1,0.9,2), (1,0,0.9,3)])
+        MQ.update([(0, 1, 0.9, 2), (1, 0, 0.9, 3)])
         print(MQ.Q_list)
-
-

--- a/dist_q_learning/test_mentors.py
+++ b/dist_q_learning/test_mentors.py
@@ -49,5 +49,3 @@ class Test(TestCase):
             env.step(mentor_act)
             env.render()
             assert mentor_act == act, f"Expected: {act}. Got: {mentor_act}"
-
-


### PR DESCRIPTION
We discussed, and alpha, beta correspond to "successes",
"failures". This was the opposite way around to how it was in the
code before, so this change swaps to correct the definition.

Also changed some stuff pycharm complains about.