### PR TITLE
Account for done states, make lr more sensible

### DIFF
--- a/dist_q_learning/agents.py
+++ b/dist_q_learning/agents.py
@@ -63,7 +63,7 @@ class FinitePessimisticAgent:
             state = int(self.env.reset())
 
             for step in range(steps_per_ep):
-                
+
                 values = [
                     self.QEstimators[self.quantile_i].estimate(state, action_i)
                     for action_i in range(self.num_actions)
@@ -88,9 +88,9 @@ class FinitePessimisticAgent:
 
                 if mentor_acted:
                     self.mentor_history.append(
-                        (state, action, reward, next_state))
+                        (state, action, reward, next_state, done))
                 
-                self.history.append((state, action, reward, next_state))
+                self.history.append((state, action, reward, next_state, done))
 
                 total_steps += 1
 
@@ -113,7 +113,7 @@ class FinitePessimisticAgent:
         rand_mentor_i = np.random.randint(
             low=0, high=len(self.mentor_history), size=self.batch_size)
         mentor_history_samples = [self.mentor_history[i] for i in rand_mentor_i]
-        
+
         self.MentorQEstimator.update(mentor_history_samples)
 
         rand_i = np.random.randint(
@@ -123,8 +123,8 @@ class FinitePessimisticAgent:
         # purposes. Possibly sample batch_size per-action in the future.
         for IRE_index, IRE in enumerate(self.IREs):
             IRE.update(
-                [(s, r) for s, a, r, _ in history_samples if IRE_index == a])
-        
+                [(s, r) for s, a, r, _, _ in history_samples if IRE_index == a])
+
         for q_estimator in self.QEstimators:
             q_estimator.update(history_samples)
 
@@ -135,10 +135,3 @@ class FinitePessimisticAgent:
             self.eps_max *= 0.999
 
         return self.eps_max * np.random.rand()
-
-                
-
-
-
-
-

--- a/dist_q_learning/test_estimators.py
+++ b/dist_q_learning/test_estimators.py
@@ -69,10 +69,11 @@ class TestQEstimator(TestCase):
     def test_update(self):
         IREs =  self.initialise_IREs()
 
-        Q = QEstimator(0.5, IREs, 0.99, 4, 2, lr=10)
+        Q = QEstimator(0.5, IREs, 0.99, 4, 2, lr=1.)
         assert np.all(Q.Q_table == 0.5)
         print(Q.Q_table)
-        Q.update([(0, 1, 0.9, 2), (1, 0, 0.9, 3)])
+        # s, a, r, s', d
+        Q.update([(0, 1, 0.9, 2, False), (1, 0, 0.9, 3, True)])
         # assert Q.Q_table[0,1] == Q.quantile + Q.lr *
         # (self.IREs[1].estimate(0)*(1 - Q.gamma) + Q.gamma * 0.5 - Q.quantile)
         print(Q.Q_table)
@@ -89,5 +90,6 @@ class TestMentorQEstimator(TestCase):
         MQ = MentorQEstimator(4, 2, 0.99)
         assert np.all(MQ.Q_list == 1)
         print(MQ.Q_list)
-        MQ.update([(0, 1, 0.9, 2), (1, 0, 0.9, 3)])
+        # s, a, r, s', d
+        MQ.update([(0, 1, 0.9, 2, False), (1, 0, 0.9, 3, True)])
         print(MQ.Q_list)


### PR DESCRIPTION
Learning rates were 1.0 which meant we were updating too heavily
on a stochastic reward function. I changed it to 0.1 default to
see what happens. We might want to consider even lower.

Also when "done" we shouldn't calculate future Q. This wasn't too
much of a problem, because we shouldn't ever be hitting "done"
states. But it's better to be correct.